### PR TITLE
Fixed clean_directories recursive double path

### DIFF
--- a/git-deploy
+++ b/git-deploy
@@ -515,7 +515,7 @@ class FTP extends Server {
 
             foreach ($filelist as $file) {
                 if ($file != '.' and $file != '..') {
-                    $this->recursive_remove($file_or_directory . "/" . $file);
+                    $this->recursive_remove($file);
                 }
             }
 


### PR DESCRIPTION
I noticed that the directories I specified with `clean_directories[]` are not cleaned up after uploading. I got the following error:

```
Warning: Invalid argument supplied for foreach() in /.../git-deploy on line 516
```

I tried to debug the problem. By logging the `$file` variable during the different steps in the `recursive_remove` function, I found out that all the files were successfully read from the directory. But when they reach the foreach loop, the recursive function adds the path a second time to the files, resulting in a false path like: `frontend/cache/compiled_templates//frontend/cache/compiled_templates/test.txt`

The $file variable normally already contains the path, so it shouldn't be added once more I think. This commit fixed issue #32. All the files I created in my FTP folder, as well as the subdirectories and their files were successfully removed after deployment. 

Is this problem only occurring on my servers? People have used the clean_directories option before with success right? 
