### PR TITLE
Error with "-l" parameter and preventative measure against newlines

### DIFF
--- a/git-deploy
+++ b/git-deploy
@@ -119,6 +119,7 @@ class Git {
             'submodules' => $submodule_paths
         );
 
+        $command = str_replace(array("\n","\r\n"), '', $command);
         $result = $this->exec($command);
 
         if (empty($result)) {


### PR DESCRIPTION
In an effort to use this code to deploy my websites via sftp I ran into a few issues in the git-deploy file.
1.  I found that the "-l" option only listed files when the --revert option was also used, and when I used "-l" on a normal attempt to deploy like with "php git-deploy -l " it would run as if it were reverting.  I looked at the code and it seemed like the $server->deploy call on line 14 was missing the "revert" argument causing the "-l" to default to false via the function definition on line 194.  Adding the "false" for the revert argument position on line 14 fixes this.
2.  On line 111 $command = "diff --name-status {$current_commit} {$target_commit}";
I found that a newline character was being added between the current commit and the target commit.  This resulted in a line in the $result variable being the value of $target_commit.  This in turn caused the script to hit the error on 140 because the line did not start with  'A','C','D' or 'M'.  I added a line of code to strip out all newline characters from the $command variable. The script works great for me now.  

This is my first time every contributing to a repository, so please feel free to advise me on anything I should or shouldn't do in making a pull request in the future. Thanks 
