### PR TITLE
adds recursvie delete of newly emptied directories for sftp

### DIFF
--- a/git-deploy
+++ b/git-deploy
@@ -403,13 +403,27 @@ class SFTP extends Server {
         }
     }
 
+    protected function recursive_remove($file_or_directory, $if_dir = false) {
+        $parent = dirname($file_or_directory);
+        if ($this->connection->delete($file_or_directory, $if_dir)) {
+            $filelist = $this->connection->nlist($parent);
+            foreach ($filelist as $file) {
+                if ($file != '.' and $file != '..') {
+                    return false;
+                }
+            }
+
+            $this->recursive_remove($parent, true);
+        }
+    }
+
     public function mkdir($file) {
         $this->connection->mkdir($file);
         logmessage("Created directory: $file");
     }
 
     public function unset_file($file) {
-        $this->connection->delete($file, true);
+        $this->recursive_remove($file, false);
         logmessage("Deleted: $file");
     }
 


### PR DESCRIPTION
In sftp directories were not being deleted.  Since git does not keep track of directories the script needs to check to see if the parent directory is empty after a file deletion and then delete the directory if it's empty. For ftp there was already a function to do this, so I took the logic from that function and rewrote it to work for sftp.
